### PR TITLE
fix typo `Liar` -> `Lidar`

### DIFF
--- a/src/HesaiLidar_General_SDK/src/PandarGeneralRaw/src/pandarGeneral_internal.cc
+++ b/src/HesaiLidar_General_SDK/src/PandarGeneralRaw/src/pandarGeneral_internal.cc
@@ -683,7 +683,7 @@ void PandarGeneral_Internal::Start() {
   enable_lidar_recv_thr_ = true;
   enable_lidar_process_thr_ = true;
   lidar_process_thr_ = new boost::thread(
-      boost::bind(&PandarGeneral_Internal::ProcessLiarPacket, this));
+      boost::bind(&PandarGeneral_Internal::ProcessLidarPacket, this));
 
   if (connect_lidar_) {
     lidar_recv_thr_ =
@@ -758,7 +758,7 @@ void PandarGeneral_Internal::FillPacket(const uint8_t *buf, const int len, doubl
   }
 }
 
-void PandarGeneral_Internal::ProcessLiarPacket() {
+void PandarGeneral_Internal::ProcessLidarPacket() {
   // LOG_FUNC();
   double lastTimestamp = 0.0f;
   struct timespec ts;

--- a/src/HesaiLidar_General_SDK/src/PandarGeneralRaw/src/pandarGeneral_internal.h
+++ b/src/HesaiLidar_General_SDK/src/PandarGeneralRaw/src/pandarGeneral_internal.h
@@ -387,7 +387,7 @@ class PandarGeneral_Internal {
   void Init();
   void RecvTask();
   void ProcessGps(const PandarGPS &gpsMsg);
-  void ProcessLiarPacket();
+  void ProcessLidarPacket();
   void PushLiDARData(PandarPacket packet);
   int ParseRawData(Pandar40PPacket *packet, const uint8_t *buf, const int len);
   int ParseL64Data(HS_LIDAR_L64_Packet *packet, const uint8_t *recvbuf, const int len);


### PR DESCRIPTION
As the title suggests, this fixes a typo in the `void ProcessLiarPacket();` function which is now called `void ProcessLidarPacket();` 
